### PR TITLE
Add support for cache expiration (irregardless of usage pattern).  Us…

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,8 +28,10 @@ The second constructor argument is an optional config (Partial&lt;CacheConfig> c
 export class CacheConfig<T> {
     // how often to check for expired entries
     public readonly checkInterval: number | "NEVER" = "NEVER";
-    // time to live after last access
+    // time to live (milliseconds)
     public readonly ttl: number | "FOREVER" = "FOREVER";
+    // specifies that entries should be removed 'ttl' milliseconds from either when the cache was accessed (read) or when the cache value was created or replaced
+    public readonly ttlAfter: "ACCESS"|"WRITE" = "ACCESS";
     // remove rejected promises?
     public readonly removeRejected: boolean = true;
     // fallback for rejected promises
@@ -55,6 +57,17 @@ const cache = singlePromiseCache(() => Promise.resolve("value"));
 const value = await cache();
 expect(value).to.eq("value");
 ```
+
+## TTL Expiry ##
+The default behavior is for values to remain in the cache for 'ttl' milliseconds since the last access.  It
+is sometimes useful for cache expiry to be relative to when the cached value was first created (or last changed).
+
+For this situation, set ttlAfter:"WRITE":
+```typescript
+new PromiseCache<string>(loader, {ttl: 1000, ttlAfter:"WRITE"});
+
+```
+
 
 ## Statistics ##
 _stats()_ returns statistics:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "ts-promise-cache",
-  "version": "0.8.1",
+  "version": "0.9.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ts-promise-cache",
-  "version": "0.8.1",
+  "version": "0.9.0",
   "license": "MIT",
   "description": "a loading cache for promises",
   "repository": "https://github.com/normartin/ts-promise-cache",

--- a/src/promise-cache.ts
+++ b/src/promise-cache.ts
@@ -72,7 +72,7 @@ export class PromiseCache<T> {
         return this.stats.export(this.cache.size);
     }
 
-    private cleanUp() {
+    cleanUp() { //  needs to be non-private so that we can call it from tests.  need to call it from tests to achieve full branch coverage.
         const now = Date.now();
 
         // workaround as for(const it of this.cache.entries()) does not work

--- a/test/promise-cache.test.ts
+++ b/test/promise-cache.test.ts
@@ -72,7 +72,7 @@ describe("Promise Cache", () => {
 
     it("should cleanup after expires", async () => {
         const loader = new TestLoader("value");
-        const cache = new PromiseCache<string>(() => loader.load(), {expires: 5, checkInterval: 2});
+        const cache = new PromiseCache<string>(() => loader.load(), {ttlAfter: "WRITE", ttl: 5, checkInterval: 2});
 
         expect(await cache.get("key")).to.eq("value");
 
@@ -113,7 +113,7 @@ describe("Promise Cache", () => {
 
     it("should expire even if no checkInterval", async () => {
         const loader = new TestLoader("value");
-        const cache = new PromiseCache<string>(() => loader.load(), {expires: 5, checkInterval: "NEVER"});
+        const cache = new PromiseCache<string>(() => loader.load(), {ttlAfter: "WRITE", ttl: 5, checkInterval: "NEVER"});
 
         expect(await cache.get("key")).to.eq("value");
 
@@ -170,7 +170,7 @@ describe("Promise Cache", () => {
             } else {
                 return Promise.resolve("ok");
             }
-        }, {removeRejected: false, expires: 5, checkInterval: "NEVER"});
+        }, {removeRejected: false, ttlAfter: "WRITE", ttl: 5, checkInterval: "NEVER"});
 
         //  first call will fail
         const error = await expectError(cache.get("key"));
@@ -227,12 +227,12 @@ describe("Promise Cache", () => {
                 default:
                     return Promise.reject(Error("too many calls"));
             }
-        }, {removeRejected: false, expires: 5, checkInterval: "NEVER"});
+        }, {removeRejected: false, ttlAfter: "WRITE", ttl: 5, checkInterval: "NEVER"});
 
         //  This will cache success only for 15ms (meaning - failures are cached for 5ms and successes for 15ms)
         const cache = new PromiseCache<string>((key) => {
             return intCache.get(key);
-        }, {removeRejected: true, expires: 20, checkInterval: "NEVER"});
+        }, {removeRejected: true, ttlAfter: "WRITE", ttl: 20, checkInterval: "NEVER"});
 
         //  zero'th call will fail:
         expect(calls).to.eq(0);


### PR DESCRIPTION
Thanks for the useful library!  How do you feel about this change?

Add support for cache expiration (irregardless of usage pattern).  Useful (for example) to handle caching of login tokens and other external things that expire and need to be re-retrieved independently.

Thanks,
Paul